### PR TITLE
Fixes iMobileDeviceFolder failing after first path

### DIFF
--- a/AltCheck-Reborn.ps1
+++ b/AltCheck-Reborn.ps1
@@ -42,8 +42,7 @@ function restartAppleMobileDeviceService {
 
 if ($Mode -eq "serviceMonitor") {
     while($true) {
-        Set-Location -Path $iMobileDeviceFolder
-        $deviceCount = (.\idevice_id.exe -l | Measure-Object).Count
+        $deviceCount = ("$iMobileDeviceFolder\idevice_id.exe -l" | Measure-Object).Count
         if ($deviceCount -eq "0") {
             Write-Host [WARN] No devices found. Restarting $appleServiceName.
             restartAppleMobileDeviceService


### PR DESCRIPTION
Since Set-Location was done inside the while loop if $iMobileDeviceFolder was not an absolute path Set-Location would try to set it again relative to its current directory. 

Removes Set-Location and makes it use the variable as the folder to get idevice_id.exe

Fixes #1 